### PR TITLE
Remove the limitation of unique cards for the deck showcase

### DIFF
--- a/alteredbuilder/decks/static/js/deck-detail.js
+++ b/alteredbuilder/decks/static/js/deck-detail.js
@@ -287,7 +287,7 @@ let deckShowcaseButton = document.getElementById("deckShowcaseButton");
 if (deckShowcaseButton) {
     deckShowcaseButton.addEventListener("click", (event) => {
         event.preventDefault();
-        let showcaseEndpoint = "https://deck-showcase.vercel.app/d/";
+        let showcaseEndpoint = "https://deck-showcase-494882337653.europe-west1.run.app/d/";
         let decklistElement = document.getElementById("decklist-text");
         let encodedList = deckfmt.encodeList(decklistElement.dataset.decklist);
         

--- a/alteredbuilder/decks/templates/decks/deck_detail.html
+++ b/alteredbuilder/decks/templates/decks/deck_detail.html
@@ -73,14 +73,7 @@
     {% endif %}
         <!-- View button -->
         <div class="col me-3">
-            
-    {% if stats.rarity_distribution.unique %}
-            <div data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="{% translate 'This feature cannot be used with unique cards<br>(Work In Progress)' %}" data-bs-html="true">
-                <a role="button" class="btn btn-sm btn-outline-warning disabled">
-                    <i class="fa-solid fa-eye"></i> {% translate "Showcase" %} <i class="fa-solid fa-arrow-up-right-from-square"></i>
-                </a>
-            </div>
-    {% elif deck.hero %}
+    {% if deck.hero %}
             <div class="col" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="{% translate 'By Taum' %}">
                 <a id="deckShowcaseButton" role="button" class="btn btn-sm btn-outline-warning">
                     <i class="fa-solid fa-eye"></i> {% translate "Showcase" %} <i class="fa-solid fa-arrow-up-right-from-square"></i>


### PR DESCRIPTION
I've removed the conditional that prevented the call to the Deck Showcase endpoint if the deck contained any unique cards. I've also changed the target endpoint to the new one, which is a Cloud Run one. We can expect to change it sooner or later, but for the time being the latest version of the service is located there.